### PR TITLE
Added non release group to exclude

### DIFF
--- a/sickbeard/helpers.py
+++ b/sickbeard/helpers.py
@@ -170,6 +170,8 @@ def remove_non_release_groups(name):
         r'-Siklopentan$': 'searchre',
         r'-Chamele0n$': 'searchre',
         r'-Obfuscated$': 'searchre',
+        r'-Pre$': 'searchre',
+        r'-postbot$': 'searchre',
         r'-BUYMORE$': 'searchre',
         r'-\[SpastikusTV\]$': 'searchre',
         r'-RP$': 'searchre',


### PR DESCRIPTION
Added 2 non release group found mostly on nzbplanet and nzbgeek
- postbot
- Pre

These words are currently prefered to the release group when renaming. This commit fixes that behavior.

- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read [contribution guide](https://github.com/SickRage/SickRage/blob/master/.github/CONTRIBUTING.md)
